### PR TITLE
feat: add --short flag to set just the version in the badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ on:
 
 See example in [cypress-react-unit-test](https://github.com/bahmutov/cypress-react-unit-test#external-examples)
 
+## Short badge
+
+You can update a "short" badge where only the version of the dependency is listed. Use `--short` flag:
+
+```shell
+npx update-badge dependency-version-badge --short --from bahmutov/cy-rollup
+```
+
+The badge is below
+
+![dependency-version-badge used in cy-rollup short](https://img.shields.io/badge/1.2.0-brightgreen)
+
 ## Debugging
 
 Run with environment variable `DEBUG=dependency-version-badge` to see verbose logs

--- a/bin/update-badge.js
+++ b/bin/update-badge.js
@@ -8,6 +8,7 @@ const { updateBadge } = require('../src/utils')
 
 const args = arg({
   '--from': String,
+  '--short': Boolean,
 })
 debug('args: %o', args)
 

--- a/bin/update-badge.js
+++ b/bin/update-badge.js
@@ -21,7 +21,7 @@ if (names.length < 1) {
 }
 
 pEachSeries(names, (name) => {
-  return updateBadge({ name, from: args['--from'] })
+  return updateBadge({ name, from: args['--from'], short: args['--short'] })
 }).catch((err) => {
   console.error(err.message)
   process.exit(1)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "test": "ava",
     "semantic-release": "semantic-release",
-    "demo": "DEBUG=dependency-version-badge ./bin/update-badge.js prettier debug"
+    "demo": "DEBUG=dependency-version-badge ./bin/update-badge.js prettier debug",
+    "demo:short": "DEBUG=dependency-version-badge ./bin/update-badge.js dependency-version-badge --short --from bahmutov/cy-rollup"
   },
   "repository": {
     "type": "git",

--- a/test/replace.test.js
+++ b/test/replace.test.js
@@ -16,7 +16,11 @@ test('replacing dependency badge', (t) => {
 
     some other text
   `
-  const replaced = replaceVersionShield(markdown, 'X', '4.5.6')
+  const replaced = replaceVersionShield({
+    markdown,
+    name: 'X',
+    newVersion: '4.5.6',
+  })
   const expected = `
     this is readme markdown
 
@@ -35,7 +39,11 @@ test('replacing dependency badge for longer name', (t) => {
 
     some other text
   `
-  const replaced = replaceVersionShield(markdown, 'my-library', '4.5.6')
+  const replaced = replaceVersionShield({
+    markdown,
+    name: 'my-library',
+    newVersion: '4.5.6',
+  })
   const expected = `
     this is readme markdown
 
@@ -54,16 +62,41 @@ test('replacing dependency badge used by another repo', (t) => {
 
     some other text
   `
-  const replaced = replaceVersionShield(
+  const replaced = replaceVersionShield({
     markdown,
-    'my-library',
-    '4.5.6',
-    'my-library-example',
-  )
+    name: 'my-library',
+    newVersion: '4.5.6',
+    usedIn: 'my-library-example',
+  })
   const expected = `
     this is readme markdown
 
     ![my-library used in my-library-example version](https://img.shields.io/badge/my--library-4.5.6-brightgreen)
+
+    some other text
+  `
+  t.is(replaced, expected)
+})
+
+test('replacing short badge', (t) => {
+  // short badge does not include the library name
+  const markdown = `
+    this is readme markdown
+
+    ![library-name short](https://img.shields.io/badge/1.2.3-brightgreen)
+
+    some other text
+  `
+  const replaced = replaceVersionShield({
+    markdown,
+    name: 'library-name',
+    newVersion: '4.5.6',
+    short: true,
+  })
+  const expected = `
+    this is readme markdown
+
+    ![library-name short](https://img.shields.io/badge/4.5.6-brightgreen)
 
     some other text
   `


### PR DESCRIPTION
- closes #13

```
npx update-badge dependency-version-badge --short --from bahmutov/cy-rollup
```

![dependency-version-badge used in cy-rollup short](https://img.shields.io/badge/1.2.0-brightgreen)