### PR TITLE
feat: add fetching latest version for NPM package

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -38,6 +38,11 @@ jobs:
           DEBUG=dependency-version-badge ./bin/update-badge.js \
             dependency-version-badge --from bahmutov/cypress-svelte-unit-test
 
+      # update color coded badges that show how far is the current version
+      # behind the latest published version of the dependency
+      - name: Update badges using --behind 🏷
+        run: npm run demo:behind
+
       # commit any changed files
       # https://github.com/mikeal/publish-to-github-action
       - name: Push any changes to repo 📤

--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ Latest version | Current version | Badge
 
 To get a color-coded badge, use CLI flag `--behind`
 
+Example color-coded badges for `ava` and `execa` dependencies are below
+
+```shell
+$ npm run demo:behind
+```
+
+<!-- prettier-ignore-start -->
+Dependency Badge | Short badge
+--- | ---
+![ava version](https://img.shields.io/badge/ava-3.13.0-brightgreen) | ![ava short](https://img.shields.io/badge/3.13.0-brightgreen)
+![execa version](https://img.shields.io/badge/execa-4.0.3-brightgreen) | ![execa short](https://img.shields.io/badge/4.0.3-brightgreen)
+<!-- prettier-ignore-end -->
+
 ## Debugging
 
 Run with environment variable `DEBUG=dependency-version-badge` to see verbose logs

--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ The badge is below
 
 ![dependency-version-badge used in cy-rollup short](https://img.shields.io/badge/1.2.0-brightgreen)
 
+## Behind the latest version
+
+By default every badge is bright green. But you can look up the latest version of the dependency and color code the badge depending on how far the current version is behind the latest version. If the current version is the latest, or a couple of minor versions behind, the badge is green. If the current version is more than a couple of minor releases behind, but is still on the same major version, the badge is yellow. If the current version is 1 or more major versions behind, the badge is red.
+
+<!-- prettier-ignore-start -->
+Latest version | Current version | Badge
+--- | --- | ---
+2.3.0 | 2.2.0 | ![up-to-date badge](https://img.shields.io/badge/2.2.0-brightgreen)
+2.3.0 | 2.0.0 | ![a few minor versions behind badge](https://img.shields.io/badge/2.0.0-yellow)
+2.3.0 | 1.19.12 | ![major version behind badge](https://img.shields.io/badge/1.19.12-red)
+<!-- prettier-ignore-end -->
+
+To get a color-coded badge, use CLI flag `--behind`
+
 ## Debugging
 
 Run with environment variable `DEBUG=dependency-version-badge` to see verbose logs

--- a/bin/update-badge.js
+++ b/bin/update-badge.js
@@ -7,8 +7,9 @@ const pEachSeries = require('p-each-series')
 const { updateBadge } = require('../src/utils')
 
 const args = arg({
-  '--from': String,
-  '--short': Boolean,
+  '--from': String, // remote github repo to check
+  '--short': Boolean, // only put the version string into to the badge without dependency name
+  '--behind': Boolean, // color code dependencies behind latest
 })
 debug('args: %o', args)
 
@@ -21,7 +22,13 @@ if (names.length < 1) {
 }
 
 pEachSeries(names, (name) => {
-  return updateBadge({ name, from: args['--from'], short: args['--short'] })
+  const options = {
+    name,
+    from: args['--from'],
+    short: args['--short'],
+    behind: args['--behind'],
+  }
+  return updateBadge(options)
 }).catch((err) => {
   console.error(err.message)
   process.exit(1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1710,7 +1710,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -1771,10 +1770,9 @@
       "dev": true
     },
     "execa": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.0.tgz",
-      "integrity": "sha512-JbDUxwV3BoT5ZVXQrSVbAiaXhXUkIwvbhPIwZ0N13kX+5yCzOhUNdocxB/UQRuYOHRYYwAxKYwJYc0T4D12pDA==",
-      "dev": true,
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+      "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
       "requires": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -1788,10 +1786,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
-          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
-          "dev": true,
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "requires": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
@@ -1801,14 +1798,12 @@
         "is-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-          "dev": true
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
         },
         "npm-run-path": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
           "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-          "dev": true,
           "requires": {
             "path-key": "^3.0.0"
           }
@@ -1816,14 +1811,12 @@
         "path-key": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
         },
         "shebang-command": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
           "requires": {
             "shebang-regex": "^3.0.0"
           }
@@ -1831,14 +1824,12 @@
         "shebang-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
         },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -1966,7 +1957,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
       "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -2204,8 +2194,7 @@
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
     },
     "ignore": {
       "version": "5.1.4",
@@ -2483,8 +2472,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "4.0.0",
@@ -2937,8 +2925,7 @@
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "merge2": {
       "version": "1.3.0",
@@ -2965,8 +2952,7 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -6667,7 +6653,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6676,7 +6661,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
       "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -7065,7 +7049,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -7464,8 +7447,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "signale": {
       "version": "1.4.0",
@@ -7693,8 +7675,7 @@
     "strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
     },
     "strip-indent": {
       "version": "2.0.0",
@@ -8155,8 +8136,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7391,8 +7391,7 @@
     "semver": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-      "dev": true
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "semver-diff": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "debug": "4.1.1",
     "execa": "4.0.3",
     "get-package-json-from-github": "1.2.1",
-    "p-each-series": "2.1.0"
+    "p-each-series": "2.1.0",
+    "semver": "7.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "arg": "4.1.3",
     "debug": "4.1.1",
+    "execa": "4.0.3",
     "get-package-json-from-github": "1.2.1",
     "p-each-series": "2.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "ava",
     "semantic-release": "semantic-release",
     "demo": "DEBUG=dependency-version-badge ./bin/update-badge.js prettier debug",
-    "demo:short": "DEBUG=dependency-version-badge ./bin/update-badge.js dependency-version-badge --short --from bahmutov/cy-rollup"
+    "demo:short": "DEBUG=dependency-version-badge ./bin/update-badge.js dependency-version-badge --short --from bahmutov/cy-rollup",
+    "demo:behind": "DEBUG=dependency-version-badge ./bin/update-badge.js ava execa --behind && DEBUG=dependency-version-badge ./bin/update-badge.js ava execa --behind --short"
   },
   "repository": {
     "type": "git",

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,10 +13,10 @@ function escapeName(name) {
 }
 
 /**
- * @returns {'green'|'yellow'|'red'} Badge color
+ * @returns {'brightgreen'|'yellow'|'red'} Badge color
  */
 function getColorBehind(newVersion, latestVersion) {
-  const green = 'green'
+  const green = 'brightgreen'
   const yellow = 'yellow'
   const red = 'red'
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@ const path = require('path')
 const fs = require('fs')
 const os = require('os')
 const execa = require('execa')
+const semver = require('semver')
 const getPackageFromGitHub = require('get-package-json-from-github')
 
 function escapeName(name) {
@@ -12,10 +13,61 @@ function escapeName(name) {
 }
 
 /**
+ * @returns {'green'|'yellow'|'red'} Badge color
+ */
+function getColorBehind(newVersion, latestVersion) {
+  const green = 'green'
+  const yellow = 'yellow'
+  const red = 'red'
+
+  if (!latestVersion) {
+    return green
+  }
+  if (newVersion === latestVersion) {
+    return green
+  }
+
+  // edge case - the new version is newer than the latest
+  if (semver.gt(newVersion, latestVersion)) {
+    return green
+  }
+
+  const parsedNewVersion = semver.parse(newVersion)
+  const parsedLatest = semver.parse(latestVersion)
+
+  const pNew = {
+    major: parsedNewVersion.major,
+    minor: parsedNewVersion.minor,
+  }
+  const pLatest = {
+    major: parsedLatest.major,
+    minor: parsedLatest.minor,
+  }
+  debug('new version %o latest %o', pNew, pLatest)
+
+  if (pNew.major === pLatest.major) {
+    if (pNew.minor >= pLatest.minor - 2) {
+      return green
+    } else {
+      return yellow
+    }
+  } else {
+    return red
+  }
+}
+
+/**
  * Replaces the whole Markdown image badge with new version badge.
  * The badge is formed like "![name version](url...escaped name-version)"
  */
-function replaceVersionShield({ markdown, name, newVersion, usedIn, short }) {
+function replaceVersionShield({
+  markdown,
+  name,
+  newVersion,
+  usedIn,
+  short,
+  latestVersion,
+}) {
   if (!name) {
     throw new Error('Missing the library name')
   }
@@ -144,7 +196,7 @@ function cleanVersion(version) {
  * Updates the given badge (if found) with new version information
  * read from the "package.json" file. Returns a promise
  */
-function updateBadge({ name, from, short }) {
+function updateBadge({ name, from, short, behind }) {
   debug('updating badge %o', { name, from, short })
 
   if (from && !isGitHubRepoUrl(from)) {
@@ -152,40 +204,47 @@ function updateBadge({ name, from, short }) {
     debug('set --from to "%s"', from)
   }
 
-  return findVersionFrom(name, from).then((currentVersion) => {
-    if (!currentVersion) {
-      const message = `Could not find dependency "${name}" among dependencies`
-      debug(message)
-      return Promise.reject(new Error(message))
-    }
+  const latestVersionPromise = behind
+    ? getLatestVersion(name)
+    : Promise.resolve(undefined)
 
-    const cleanedVersion = cleanVersion(currentVersion)
-    if (!cleanedVersion) {
-      const message = `Could not clean version "${currentVersion}" for ${name}`
-      debug(message)
-      return Promise.reject(new Error(message))
-    }
-    currentVersion = cleanedVersion
+  return latestVersionPromise.then((latestVersion) => {
+    return findVersionFrom(name, from).then((currentVersion) => {
+      if (!currentVersion) {
+        const message = `Could not find dependency "${name}" among dependencies`
+        debug(message)
+        return Promise.reject(new Error(message))
+      }
 
-    debug('current dependency version %s@%s', name, currentVersion)
+      const cleanedVersion = cleanVersion(currentVersion)
+      if (!cleanedVersion) {
+        const message = `Could not clean version "${currentVersion}" for ${name}`
+        debug(message)
+        return Promise.reject(new Error(message))
+      }
+      currentVersion = cleanedVersion
 
-    const readmeFilename = path.join(process.cwd(), 'README.md')
-    const readmeText = fs.readFileSync(readmeFilename, 'utf8')
-    const usedIn = parseGitHubRepo(from)
+      debug('current dependency version %s@%s', name, currentVersion)
 
-    const maybeChangedText = replaceVersionShield({
-      markdown: readmeText,
-      name,
-      newVersion: currentVersion,
-      usedIn,
-      short,
+      const readmeFilename = path.join(process.cwd(), 'README.md')
+      const readmeText = fs.readFileSync(readmeFilename, 'utf8')
+      const usedIn = parseGitHubRepo(from)
+
+      const maybeChangedText = replaceVersionShield({
+        markdown: readmeText,
+        name,
+        newVersion: currentVersion,
+        usedIn,
+        short,
+        latestVersion,
+      })
+      if (maybeChangedText !== readmeText) {
+        console.log('saving updated readme with %s@%s', name, currentVersion)
+        fs.writeFileSync(readmeFilename, maybeChangedText, 'utf8')
+      } else {
+        debug('no updates for dependency %s', name)
+      }
     })
-    if (maybeChangedText !== readmeText) {
-      console.log('saving updated readme with %s@%s', name, currentVersion)
-      fs.writeFileSync(readmeFilename, maybeChangedText, 'utf8')
-    } else {
-      debug('no updates for dependency %s', name)
-    }
   })
 }
 
@@ -210,7 +269,11 @@ function getLatestVersion(npmPackageName) {
       return new Error(npmPackageName)
     }
 
-    return latest.split(':')[1].trim()
+    const version = latest.split(':')[1].trim()
+    const cleaned = semver.clean(version)
+    debug('latest version %o', { version, cleaned })
+
+    return cleaned
   })
 }
 
@@ -220,4 +283,5 @@ module.exports = {
   parseGitHubRepo,
   cleanVersion,
   getLatestVersion,
+  getColorBehind,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -85,21 +85,29 @@ function replaceVersionShield({
     ? `${name} used in ${usedIn} ${suffix}`
     : `${name} ${suffix}`
 
+  const badgeColor = getColorBehind(newVersion, latestVersion)
+  debug(
+    'badge color from %s to %s is %s',
+    newVersion,
+    latestVersion,
+    badgeColor,
+  )
+
   const fullBadgeVersionRe = new RegExp(
     `\\!\\[${label}\\]` +
       '\\(https://img\\.shields\\.io/badge/' +
       escapedName +
-      '-(\\d+\\.\\d+\\.\\d+)-brightgreen\\)',
+      '-(\\d+\\.\\d+\\.\\d+)-(?:brightgreen|yellow|red)\\)',
   )
 
   const shortBadgeVersionRe = new RegExp(
     `\\!\\[${label}\\]` +
       '\\(https://img\\.shields\\.io/badge/' +
-      '(\\d+\\.\\d+\\.\\d+)-brightgreen\\)',
+      '(\\d+\\.\\d+\\.\\d+)-(?:brightgreen|yellow|red)\\)',
   )
 
-  const fullBadge = `![${label}](https://img.shields.io/badge/${escapedName}-${newVersion}-brightgreen)`
-  const shortBadge = `![${label}](https://img.shields.io/badge/${newVersion}-brightgreen)`
+  const fullBadge = `![${label}](https://img.shields.io/badge/${escapedName}-${newVersion}-${badgeColor})`
+  const shortBadge = `![${label}](https://img.shields.io/badge/${newVersion}-${badgeColor})`
 
   const badgeVersionRe = short ? shortBadgeVersionRe : fullBadgeVersionRe
   const badge = short ? shortBadge : fullBadge

--- a/test/latest.test.js
+++ b/test/latest.test.js
@@ -1,0 +1,13 @@
+const test = require('ava')
+const debug = require('debug')('test')
+const { getLatestVersion } = require('../src/utils')
+
+test('fetches latest cypress version', async (t) => {
+  const latest = await getLatestVersion('cypress')
+  debug('latest Cypress version %s', latest)
+  t.true(/^\d+\.\d+\.\d+$/.test(latest), 'is x.y.z version')
+})
+
+test('throws for non-existent packages', async (t) => {
+  await t.throwsAsync(() => getLatestVersion('does-not-exist-probably-xyz123'))
+})

--- a/test/replace.test.js
+++ b/test/replace.test.js
@@ -6,29 +6,31 @@ const {
   getColorBehind,
 } = require('../src/utils')
 
+const green = 'brightgreen'
+
 test('without latest version', (t) => {
   const color = getColorBehind('1.2.3')
-  t.is(color, 'green')
+  t.is(color, green)
 })
 
 test('compares same version', (t) => {
   const color = getColorBehind('1.2.3', '1.2.3')
-  t.is(color, 'green')
+  t.is(color, green)
 })
 
 test('ten patches behind', (t) => {
   const color = getColorBehind('1.2.20', '1.2.30')
-  t.is(color, 'green')
+  t.is(color, green)
 })
 
 test('one minor behind', (t) => {
   const color = getColorBehind('1.1.20', '1.2.30')
-  t.is(color, 'green')
+  t.is(color, green)
 })
 
 test('two minors behind', (t) => {
   const color = getColorBehind('1.0.20', '1.2.30')
-  t.is(color, 'green')
+  t.is(color, green)
 })
 
 test('three minors behind', (t) => {
@@ -53,7 +55,7 @@ test('three majors behind', (t) => {
 
 test('edge case: new version is above latest tag', (t) => {
   const color = getColorBehind('5.99.99', '1.2.30')
-  t.is(color, 'green')
+  t.is(color, green)
 })
 
 test('get name from github url', (t) => {

--- a/test/replace.test.js
+++ b/test/replace.test.js
@@ -1,6 +1,60 @@
 const test = require('ava')
 const debug = require('debug')('test')
-const { replaceVersionShield, parseGitHubRepo } = require('../src/utils')
+const {
+  replaceVersionShield,
+  parseGitHubRepo,
+  getColorBehind,
+} = require('../src/utils')
+
+test('without latest version', (t) => {
+  const color = getColorBehind('1.2.3')
+  t.is(color, 'green')
+})
+
+test('compares same version', (t) => {
+  const color = getColorBehind('1.2.3', '1.2.3')
+  t.is(color, 'green')
+})
+
+test('ten patches behind', (t) => {
+  const color = getColorBehind('1.2.20', '1.2.30')
+  t.is(color, 'green')
+})
+
+test('one minor behind', (t) => {
+  const color = getColorBehind('1.1.20', '1.2.30')
+  t.is(color, 'green')
+})
+
+test('two minors behind', (t) => {
+  const color = getColorBehind('1.0.20', '1.2.30')
+  t.is(color, 'green')
+})
+
+test('three minors behind', (t) => {
+  const color = getColorBehind('1.0.20', '1.3.30')
+  t.is(color, 'yellow')
+})
+
+test('four minors behind', (t) => {
+  const color = getColorBehind('1.0.20', '1.4.30')
+  t.is(color, 'yellow')
+})
+
+test('one major behind', (t) => {
+  const color = getColorBehind('1.10.0', '2.4.0')
+  t.is(color, 'red')
+})
+
+test('three majors behind', (t) => {
+  const color = getColorBehind('1.10.0', '4.4.0')
+  t.is(color, 'red')
+})
+
+test('edge case: new version is above latest tag', (t) => {
+  const color = getColorBehind('5.99.99', '1.2.30')
+  t.is(color, 'green')
+})
 
 test('get name from github url', (t) => {
   const url = 'https://github.com/bahmutov/dependency-version-badge'

--- a/test/replace.test.js
+++ b/test/replace.test.js
@@ -87,6 +87,77 @@ test('replacing dependency badge', (t) => {
   t.is(replaced, expected)
 })
 
+test('replacing yellow dependency badge with green', (t) => {
+  const markdown = `
+    this is readme markdown
+
+    ![X version](https://img.shields.io/badge/X-1.2.3-yellow)
+
+    some other text
+  `
+  const replaced = replaceVersionShield({
+    markdown,
+    name: 'X',
+    newVersion: '4.5.6',
+  })
+  const expected = `
+    this is readme markdown
+
+    ![X version](https://img.shields.io/badge/X-4.5.6-brightgreen)
+
+    some other text
+  `
+  t.is(replaced, expected)
+})
+
+test('replacing yellow dependency badge with yellow', (t) => {
+  const markdown = `
+    this is readme markdown
+
+    ![X version](https://img.shields.io/badge/X-1.2.3-yellow)
+
+    some other text
+  `
+  const replaced = replaceVersionShield({
+    markdown,
+    name: 'X',
+    newVersion: '4.5.6',
+    latestVersion: '4.8.0',
+  })
+  const expected = `
+    this is readme markdown
+
+    ![X version](https://img.shields.io/badge/X-4.5.6-yellow)
+
+    some other text
+  `
+  t.is(replaced, expected)
+})
+
+test('replacing green dependency badge with red', (t) => {
+  const markdown = `
+    this is readme markdown
+
+    ![X version](https://img.shields.io/badge/X-1.2.3-brightgreen)
+
+    some other text
+  `
+  const replaced = replaceVersionShield({
+    markdown,
+    name: 'X',
+    newVersion: '4.5.6', // major version behind the latest!
+    latestVersion: '5.0.0',
+  })
+  const expected = `
+    this is readme markdown
+
+    ![X version](https://img.shields.io/badge/X-4.5.6-red)
+
+    some other text
+  `
+  t.is(replaced, expected)
+})
+
 test('replacing dependency badge for longer name', (t) => {
   const markdown = `
     this is readme markdown
@@ -153,6 +224,31 @@ test('replacing short badge', (t) => {
     this is readme markdown
 
     ![library-name short](https://img.shields.io/badge/4.5.6-brightgreen)
+
+    some other text
+  `
+  t.is(replaced, expected)
+})
+
+test('replacing green dependency badge with red (short)', (t) => {
+  const markdown = `
+    this is readme markdown
+
+    ![X short](https://img.shields.io/badge/1.2.3-brightgreen)
+
+    some other text
+  `
+  const replaced = replaceVersionShield({
+    markdown,
+    name: 'X',
+    newVersion: '4.5.6', // major version behind the latest!
+    latestVersion: '5.0.0',
+    short: true,
+  })
+  const expected = `
+    this is readme markdown
+
+    ![X short](https://img.shields.io/badge/4.5.6-red)
 
     some other text
   `

--- a/test/replace.test.js
+++ b/test/replace.test.js
@@ -58,6 +58,11 @@ test('edge case: new version is above latest tag', (t) => {
   t.is(color, green)
 })
 
+test('2.0.0 behind 2.3.0 color', (t) => {
+  const color = getColorBehind('2.0.0', '2.3.0')
+  t.is(color, 'yellow')
+})
+
 test('get name from github url', (t) => {
   const url = 'https://github.com/bahmutov/dependency-version-badge'
   const name = parseGitHubRepo(url)


### PR DESCRIPTION
- closes #4

Adds flag `--behind` that changes the color of the badge depending on how far the used version is behind the latest public version

- green - the used version is the latest or up to 2 minor versions behind
- yellow - the used version is the same major version
- red - the used version is one or more major versions behind